### PR TITLE
Add basic instructor dashboard

### DIFF
--- a/frontend/src/api/analytics.ts
+++ b/frontend/src/api/analytics.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { LessonAnalytics } from '@/types/analytics';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+const getToken = () => {
+  return localStorage.getItem('authToken') || '';
+};
+
+export const getInstructorAnalytics = async (): Promise<LessonAnalytics[]> => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/api/analytics/instructor/analytics`, {
+      headers: {
+        'Authorization': `Bearer ${getToken()}`
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching instructor analytics:', error);
+    throw error;
+  }
+};

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -33,6 +33,7 @@ const Navbar: React.FC = () => {
     { label: 'Courses', path: '/courses' },
     { label: 'Language Preservation', path: '/language-preservation' },
     { label: 'Dashboard', path: '/dashboard', authRequired: true },
+    { label: 'Instructor Dashboard', path: '/instructor-dashboard', authRequired: true },
   ]
 
   return (

--- a/frontend/src/pages/instructor-dashboard.tsx
+++ b/frontend/src/pages/instructor-dashboard.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '@/components/layout';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Typography, Box, CircularProgress } from '@mui/material';
+import { getInstructorAnalytics } from '@/api/analytics';
+import { LessonAnalytics } from '@/types/analytics';
+
+const InstructorDashboard: React.FC = () => {
+  const [data, setData] = useState<LessonAnalytics[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const analytics = await getInstructorAnalytics();
+        setData(analytics);
+      } catch (error) {
+        console.error('Failed to load analytics', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <Layout title="Instructor Dashboard | AI-Powered Learning Platform">
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="60vh">
+          <CircularProgress />
+        </Box>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout title="Instructor Dashboard | AI-Powered Learning Platform">
+      <Typography variant="h4" gutterBottom>
+        Lesson Analytics
+      </Typography>
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Lesson</TableCell>
+              <TableCell align="right">Avg Score</TableCell>
+              <TableCell align="right">#Attempts</TableCell>
+              <TableCell align="right">Last Activity</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.map((row, index) => (
+              <TableRow key={index}>
+                <TableCell component="th" scope="row">
+                  {row.lessonTitle}
+                </TableCell>
+                <TableCell align="right">{row.avgScore}</TableCell>
+                <TableCell align="right">{row.attempts}</TableCell>
+                <TableCell align="right">{row.lastActivity}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Layout>
+  );
+};
+
+export default InstructorDashboard;

--- a/frontend/src/types/analytics.ts
+++ b/frontend/src/types/analytics.ts
@@ -1,0 +1,6 @@
+export interface LessonAnalytics {
+  lessonTitle: string;
+  avgScore: number;
+  attempts: number;
+  lastActivity: string;
+}


### PR DESCRIPTION
## Summary
- fetch instructor analytics from backend
- define `LessonAnalytics` type
- show a minimal table of lesson metrics
- expose the new page from navbar

## Testing
- `pre-commit run --files frontend/src/api/analytics.ts frontend/src/types/analytics.ts frontend/src/pages/instructor-dashboard.tsx frontend/src/components/Navbar.tsx`

------
https://chatgpt.com/codex/tasks/task_e_687d3ccd80d08333ba7feee20d48537c