### PR TITLE
Add basic lesson editor UI and API endpoint

### DIFF
--- a/backend/api/lessons/crud.py
+++ b/backend/api/lessons/crud.py
@@ -1,0 +1,19 @@
+from sqlalchemy.orm import Session
+from . import schemas
+from ..courses import models
+
+
+def get_lessons(db: Session, skip: int = 0, limit: int = 100):
+    return db.query(models.Lesson).offset(skip).limit(limit).all()
+
+
+def get_lesson(db: Session, lesson_id: int):
+    return db.query(models.Lesson).filter(models.Lesson.id == lesson_id).first()
+
+
+def create_lesson(db: Session, lesson: schemas.LessonCreate):
+    db_lesson = models.Lesson(**lesson.dict())
+    db.add(db_lesson)
+    db.commit()
+    db.refresh(db_lesson)
+    return db_lesson

--- a/backend/api/lessons/routes.py
+++ b/backend/api/lessons/routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List
-from ...core.database import get_db
+from ...core.database.db import get_db
 from . import schemas, crud
 
 router = APIRouter()

--- a/backend/api/lessons/schemas.py
+++ b/backend/api/lessons/schemas.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class LessonBase(BaseModel):
+    title: str
+    content: str
+    description: Optional[str] = None
+    order: Optional[int] = None
+    difficulty: Optional[str] = None
+    course_id: int
+
+class LessonCreate(LessonBase):
+    pass
+
+class Lesson(LessonBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/frontend/src/api/lessons.ts
+++ b/frontend/src/api/lessons.ts
@@ -21,6 +21,23 @@ export const getLesson = async (lessonId: number): Promise<Lesson> => {
   }
 };
 
+export const createLesson = async (
+  lessonData: Omit<Lesson, 'id'>
+): Promise<Lesson> => {
+  try {
+    const response = await axios.post<Lesson>(`${API_BASE_URL}/api/lessons/`, lessonData, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${getToken()}`
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error creating lesson:', error);
+    throw error;
+  }
+};
+
 export const getAudioLesson = async (topic: string, era: string): Promise<{ audio_url: string }> => {
   try {
     const response = await axios.get(`${API_BASE_URL}/api/lessons/audio`, {

--- a/frontend/src/components/lessons/LessonEditor.tsx
+++ b/frontend/src/components/lessons/LessonEditor.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react'
+import { Box, Button, TextField } from '@mui/material'
+import { createLesson } from '@/api/lessons'
+import { Lesson } from '@/types/course'
+
+interface LessonEditorProps {
+  courseId: number
+}
+
+const LessonEditor: React.FC<LessonEditorProps> = ({ courseId }) => {
+  const [content, setContent] = useState('')
+  const [title, setTitle] = useState('')
+
+  const handleSave = async () => {
+    const lessonData: Omit<Lesson, 'id'> = {
+      title,
+      description: '',
+      content,
+      order: 1,
+      difficulty: 'easy',
+      course_id: courseId,
+    }
+    await createLesson(lessonData)
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" gap={2}>
+      <TextField label="Title" value={title} onChange={e => setTitle(e.target.value)} fullWidth />
+      <TextField
+        label="Content (Markdown)"
+        value={content}
+        onChange={e => setContent(e.target.value)}
+        fullWidth
+        multiline
+        rows={10}
+      />
+      <Button variant="contained" onClick={handleSave}>Save</Button>
+    </Box>
+  )
+}
+
+export default LessonEditor

--- a/frontend/src/pages/lessons/create.tsx
+++ b/frontend/src/pages/lessons/create.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import Layout from '@/components/layout'
+import LessonEditor from '@/components/lessons/LessonEditor'
+import { Typography, Box } from '@mui/material'
+
+const CreateLessonPage: React.FC = () => {
+  const courseId = 1 // placeholder course ID
+  return (
+    <Layout title="Create Lesson | AI-Powered Learning Platform">
+      <Box maxWidth={800} margin="auto">
+        <Typography variant="h3" component="h1" gutterBottom>
+          New Lesson
+        </Typography>
+        <LessonEditor courseId={courseId} />
+      </Box>
+    </Layout>
+  )
+}
+
+export default CreateLessonPage


### PR DESCRIPTION
## Summary
- create CRUD and schema modules for lessons
- expose POST `/api/lessons` for creating lessons
- add frontend API helper for `createLesson`
- implement a simple Markdown editor component
- new page at `/lessons/create` to save lessons

## Testing
- `pre-commit run --files frontend/src/api/lessons.ts frontend/src/components/lessons/LessonEditor.tsx frontend/src/pages/lessons/create.tsx backend/api/lessons/routes.py backend/api/lessons/schemas.py backend/api/lessons/crud.py`

------
https://chatgpt.com/codex/tasks/task_e_687d3cb95cc083338886a091d403f4c1