### PR TITLE
Add quiz API router

### DIFF
--- a/backend/api/quizzes/crud.py
+++ b/backend/api/quizzes/crud.py
@@ -1,0 +1,15 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from typing import List
+from .models import QuizResult
+
+async def create_quiz_result(db: AsyncSession, user_id: int, lesson_id: int, score: int, answers: list) -> QuizResult:
+    quiz = QuizResult(user_id=user_id, lesson_id=lesson_id, score=score, answers=answers)
+    db.add(quiz)
+    await db.commit()
+    await db.refresh(quiz)
+    return quiz
+
+async def get_results_by_lesson(db: AsyncSession, lesson_id: int) -> List[QuizResult]:
+    results = await db.execute(select(QuizResult).filter(QuizResult.lesson_id == lesson_id))
+    return results.scalars().all()

--- a/backend/api/quizzes/models.py
+++ b/backend/api/quizzes/models.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, ForeignKey, JSON, DateTime
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from ...core.database import Base
+
+class QuizResult(Base):
+    __tablename__ = "quiz_results"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    lesson_id = Column(Integer, ForeignKey("lessons.id"))
+    score = Column(Integer)
+    answers = Column(JSON)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User")
+    lesson = relationship("Lesson")

--- a/backend/api/quizzes/routes.py
+++ b/backend/api/quizzes/routes.py
@@ -1,0 +1,76 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from typing import List
+
+from ...core.database import get_async_db
+from ..auth import crud as auth_crud
+from ..courses import models as course_models
+from ..users import schemas as user_schemas
+from ...teacher_agents.history_agent import HistoryTeacher
+from ...teacher_agents.math_agent import MathTeacher
+from . import schemas, crud
+
+router = APIRouter()
+
+history_teacher = HistoryTeacher(model="gpt-3.5-turbo")
+math_teacher = MathTeacher(model="gpt-3.5-turbo")
+
+async def _get_lesson_course(db: AsyncSession, lesson_id: int):
+    lesson_res = await db.execute(select(course_models.Lesson).filter(course_models.Lesson.id == lesson_id))
+    lesson = lesson_res.scalar_one_or_none()
+    if not lesson:
+        raise HTTPException(status_code=404, detail="Lesson not found")
+    course_res = await db.execute(select(course_models.Course).filter(course_models.Course.id == lesson.course_id))
+    course = course_res.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=404, detail="Course not found")
+    return lesson, course
+
+@router.post("/generate")
+async def generate_quiz(
+    payload: schemas.QuizGenerateRequest,
+    db: AsyncSession = Depends(get_async_db),
+    current_user: user_schemas.User = Depends(auth_crud.get_current_user),
+):
+    lesson, course = await _get_lesson_course(db, payload.lesson_id)
+    if course.type == "history":
+        quiz = await history_teacher.generate_quiz(lesson.content)
+    elif course.type == "math":
+        quiz = await math_teacher.generate_quiz(lesson.content)
+    else:
+        raise HTTPException(status_code=400, detail="Quiz generation not supported for this course")
+    return {"quiz": quiz}
+
+@router.post("/submit", response_model=schemas.QuizResult)
+async def submit_quiz(
+    submission: schemas.QuizSubmission,
+    db: AsyncSession = Depends(get_async_db),
+    current_user: user_schemas.User = Depends(auth_crud.get_current_user),
+):
+    lesson, course = await _get_lesson_course(db, submission.lesson_id)
+    if course.type == "history":
+        teacher = history_teacher
+    elif course.type == "math":
+        teacher = math_teacher
+    else:
+        raise HTTPException(status_code=400, detail="Quiz grading not supported for this course")
+
+    total = len(submission.answers)
+    correct = 0
+    for ans in submission.answers:
+        grade = await teacher.grade_answer(ans.question, ans.student_answer, ans.correct_answer)
+        if grade >= 1:
+            correct += 1
+    score = int((correct / total) * 100) if total else 0
+    result = await crud.create_quiz_result(db, current_user.id, submission.lesson_id, score, [a.dict() for a in submission.answers])
+    return result
+
+@router.get("/{lesson_id}/results", response_model=List[schemas.QuizResult])
+async def get_results(
+    lesson_id: int,
+    db: AsyncSession = Depends(get_async_db),
+    current_user: user_schemas.User = Depends(auth_crud.get_current_user),
+):
+    results = await crud.get_results_by_lesson(db, lesson_id)
+    return results

--- a/backend/api/quizzes/schemas.py
+++ b/backend/api/quizzes/schemas.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from typing import List
+from datetime import datetime
+
+class QuizGenerateRequest(BaseModel):
+    lesson_id: int
+
+class QuizAnswer(BaseModel):
+    question: str
+    student_answer: str
+    correct_answer: str
+
+class QuizSubmission(BaseModel):
+    lesson_id: int
+    answers: List[QuizAnswer]
+
+class QuizResult(BaseModel):
+    id: int
+    user_id: int
+    lesson_id: int
+    score: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from .api.courses.routes import router as course_router
 from .api.lessons.routes import router as lesson_router
 from .api.notifications.routes import router as notification_router
 from .api.analytics.routes import router as analytics_router
+from .api.quizzes.routes import router as quiz_router
 from .api.recommendations.routes import router as recommendation_router
 from .teacher_agents.history_agent import HistoryTeacher
 from .teacher_agents.science_agent import ScienceAgent
@@ -43,6 +44,7 @@ app.include_router(course_router, prefix="/api/courses", tags=["Courses"])
 app.include_router(lesson_router, prefix="/api/lessons", tags=["Lessons"])
 app.include_router(notification_router, prefix="/api/notifications", tags=["Notifications"])
 app.include_router(analytics_router, prefix="/api/analytics", tags=["Analytics"])
+app.include_router(quiz_router, prefix="/api/quizzes", tags=["Quizzes"])
 app.include_router(recommendation_router, prefix="/api/recommendations", tags=["Recommendations"])
 
 # Initialize components

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from backend.api.auth import routes as auth_routes
 from backend.api.lessons import routes as lesson_routes
 from backend.api.notifications import routes as notification_routes
 from backend.api.analytics import routes as analytics_routes
+from backend.api.quizzes import routes as quiz_routes
 from backend.core.config.settings import settings
 
 # Ensure Brave Search API key is set
@@ -30,6 +31,7 @@ app.include_router(course_routes.router, prefix="/api/courses", tags=["Courses"]
 app.include_router(lesson_routes.router, prefix="/api/lessons", tags=["Lessons"])
 app.include_router(notification_routes.router, prefix="/api/notifications", tags=["Notifications"])
 app.include_router(analytics_routes.router, prefix="/api/analytics", tags=["Analytics"])
+app.include_router(quiz_routes.router, prefix="/api/quizzes", tags=["Quizzes"])
 
 @app.on_event("startup")
 async def startup_event():


### PR DESCRIPTION
## Summary
- expose quiz generation via new `/api/quizzes` router
- auto-grade and store quiz results
- wire up new router in both entrypoints

## Testing
- `pre-commit run --files backend/api/quizzes/models.py backend/api/quizzes/schemas.py backend/api/quizzes/crud.py backend/api/quizzes/routes.py main.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_687d416da4308333b5efb09204bd39ea