### PR TITLE
Implement teacher/student roles

### DIFF
--- a/backend/api/analytics/routes.py
+++ b/backend/api/analytics/routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from typing import List
 from ...core.database import get_db
@@ -11,17 +11,13 @@ router = APIRouter()
 async def get_course_analytics(
     course_id: int,
     db: Session = Depends(get_db),
-    current_user: schemas.User = Depends(auth_crud.get_current_user)
+    current_user: schemas.User = Depends(auth_crud.get_current_teacher)
 ):
-    if not current_user.is_instructor:
-        raise HTTPException(status_code=403, detail="Not authorized to view analytics")
     return crud.get_course_analytics(db, course_id)
 
 @router.get("/instructor/analytics", response_model=schemas.InstructorAnalytics)
 async def get_instructor_analytics(
     db: Session = Depends(get_db),
-    current_user: schemas.User = Depends(auth_crud.get_current_user)
+    current_user: schemas.User = Depends(auth_crud.get_current_teacher)
 ):
-    if not current_user.is_instructor:
-        raise HTTPException(status_code=403, detail="Not authorized to view analytics")
     return crud.get_instructor_analytics(db, current_user.id)

--- a/backend/api/auth/schemas.py
+++ b/backend/api/auth/schemas.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, EmailStr
+from enum import Enum
 
 class Token(BaseModel):
     access_token: str
@@ -12,15 +13,22 @@ class TokenRefresh(BaseModel):
 class TokenData(BaseModel):
     username: str = None
 
+class UserRole(str, Enum):
+    STUDENT = "student"
+    TEACHER = "teacher"
+
+
 class UserBase(BaseModel):
     email: EmailStr
 
 class UserCreate(UserBase):
     password: str
+    role: UserRole = UserRole.STUDENT
 
 class User(UserBase):
     id: int
     is_active: bool
+    role: UserRole
 
     class Config:
         orm_mode = True

--- a/backend/api/users/crud.py
+++ b/backend/api/users/crud.py
@@ -55,7 +55,12 @@ async def get_users(db: AsyncSession, skip: int = 0, limit: int = 100) -> List[m
 
 async def create_user(db: AsyncSession, user: schemas.UserCreate):
     hashed_password = get_password_hash(user.password)
-    db_user = models.User(email=user.email, hashed_password=hashed_password)
+    db_user = models.User(
+        email=user.email,
+        hashed_password=hashed_password,
+        username=getattr(user, "username", None),
+        role=user.role.value if hasattr(user, "role") else models.UserRole.STUDENT.value,
+    )
     db.add(db_user)
     await db.commit()
     await db.refresh(db_user)

--- a/backend/api/users/models.py
+++ b/backend/api/users/models.py
@@ -1,5 +1,11 @@
 from sqlalchemy import Column, Integer, String, Boolean, ARRAY, JSON
 from ...core.database import Base
+import enum
+
+
+class UserRole(str, enum.Enum):
+    STUDENT = "student"
+    TEACHER = "teacher"
 
 class User(Base):
     __tablename__ = "users"
@@ -12,7 +18,7 @@ class User(Base):
     interests = Column(String)
     completed_lessons = Column(ARRAY(Integer), default=[])
     is_active = Column(Boolean, default=True)
-    is_instructor = Column(Boolean, default=False)
+    role = Column(String, default=UserRole.STUDENT.value, nullable=False)
     level = Column(Integer, default=1)
     xp = Column(Integer, default=0)
     achievements = Column(JSON, default=[])

--- a/backend/api/users/schemas.py
+++ b/backend/api/users/schemas.py
@@ -1,8 +1,14 @@
 from pydantic import BaseModel, EmailStr
 from typing import Optional, List
+from enum import Enum
 from ..courses.schemas import Course
 
 # ... (existing code)
+
+class UserRole(str, Enum):
+    STUDENT = "student"
+    TEACHER = "teacher"
+
 
 class UserBase(BaseModel):
     email: str
@@ -10,10 +16,12 @@ class UserBase(BaseModel):
 
 class UserCreate(UserBase):
     password: str
+    role: UserRole = UserRole.STUDENT
 
 class User(UserBase):
     id: int
     is_active: bool
+    role: UserRole
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- add `UserRole` enum and role column on users table
- include role in access and refresh tokens
- add `get_current_teacher` dependency
- use teacher-only guard for analytics endpoints
- expose role field in API schemas

## Testing
- `pre-commit run --files backend/api/analytics/routes.py backend/api/auth/crud.py backend/api/auth/schemas.py backend/api/users/crud.py backend/api/users/models.py backend/api/users/schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_687d416647548333ad6a70d82b7fd589