### PR TITLE
Add quiz API service

### DIFF
--- a/backend/api/quizzes/crud.py
+++ b/backend/api/quizzes/crud.py
@@ -1,0 +1,18 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from ..courses.models import Lesson, Course
+from ..gradebook import crud as gradebook_crud, schemas as gradebook_schemas
+
+async def get_lesson_with_course(db: AsyncSession, lesson_id: int):
+    result = await db.execute(select(Lesson).where(Lesson.id == lesson_id))
+    lesson = result.scalar_one_or_none()
+    if not lesson:
+        return None, None
+    course_result = await db.execute(select(Course).where(Course.id == lesson.course_id))
+    course = course_result.scalar_one_or_none()
+    return lesson, course
+
+async def save_quiz_result(db: AsyncSession, user_id: int, lesson_id: int, score: float):
+    data = gradebook_schemas.QuizResultCreate(user_id=user_id, lesson_id=lesson_id, score=score)
+    return await gradebook_crud.create_quiz_result(db, data)

--- a/backend/api/quizzes/routes.py
+++ b/backend/api/quizzes/routes.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List
+
+from ...core.database import get_async_db
+from ..auth import crud as auth_crud
+from ..users.schemas import User
+from . import schemas, crud
+from ..teacher_agents.history_agent import HistoryTeacher
+from ..teacher_agents.math_agent import MathTeacher
+from ..teacher_agents.language_agent import LanguageTeacher
+from ..teacher_agents.science_agent import ScienceTeacherAgent
+from ..teacher_agents.tech_agent import TechTeacherAgent
+
+router = APIRouter()
+
+
+def _get_teacher(course_type: str, model_name: str | None = None):
+    model = model_name or "gpt-3.5-turbo"
+    course_type = (course_type or "").lower()
+    if course_type == "history":
+        return HistoryTeacher(model)
+    if course_type == "math":
+        return MathTeacher(model)
+    if course_type == "science":
+        return ScienceTeacherAgent(model_name=model)
+    if course_type in {"tech", "technology"}:
+        return TechTeacherAgent(model_name=model)
+    if course_type == "language":
+        return LanguageTeacher(model)
+    return HistoryTeacher(model)
+
+
+@router.post("/generate")
+async def generate_quiz(
+    request: schemas.QuizGenerationRequest,
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(auth_crud.get_current_user),
+):
+    lesson, course = await crud.get_lesson_with_course(db, request.lesson_id)
+    if not lesson or not course:
+        raise HTTPException(status_code=404, detail="Lesson not found")
+    teacher = _get_teacher(course.type, course.model)
+    quiz = await teacher.generate_quiz(lesson.content)
+    return {"quiz": quiz}
+
+
+@router.post("/submit", response_model=crud.gradebook_schemas.QuizResult)
+async def submit_quiz(
+    submission: schemas.QuizSubmission,
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(auth_crud.get_current_user),
+):
+    if submission.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized for this user")
+    lesson, course = await crud.get_lesson_with_course(db, submission.lesson_id)
+    if not lesson or not course:
+        raise HTTPException(status_code=404, detail="Lesson not found")
+    if not submission.answers:
+        raise HTTPException(status_code=400, detail="No answers provided")
+    correct = 0
+    for ans in submission.answers:
+        if ans.student_answer.strip().lower() == ans.correct_answer.strip().lower():
+            correct += 1
+    score = (correct / len(submission.answers)) * 100
+    result = await crud.save_quiz_result(db, submission.user_id, submission.lesson_id, score)
+    return result
+
+
+@router.get("/{lesson_id}/results", response_model=List[crud.gradebook_schemas.QuizResult])
+async def lesson_results(lesson_id: int, db: AsyncSession = Depends(get_async_db)):
+    from ..gradebook import crud as gradebook_crud
+
+    return await gradebook_crud.get_results_by_lesson(db, lesson_id)

--- a/backend/api/quizzes/schemas.py
+++ b/backend/api/quizzes/schemas.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import List
+
+class QuizGenerationRequest(BaseModel):
+    lesson_id: int
+
+class QuizQuestionSubmission(BaseModel):
+    question: str
+    student_answer: str
+    correct_answer: str
+
+class QuizSubmission(BaseModel):
+    user_id: int
+    lesson_id: int
+    answers: List[QuizQuestionSubmission]

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from .api.notifications.routes import router as notification_router
 from .api.analytics.routes import router as analytics_router
 from .api.recommendations.routes import router as recommendation_router
 from .api.billing.routes import router as billing_router
+from .api.quizzes.routes import router as quiz_router
 from .teacher_agents.history_agent import HistoryTeacher
 from .teacher_agents.science_agent import ScienceAgent
 from .teacher_agents.tech_agent import TechTeacherAgent
@@ -46,6 +47,7 @@ app.include_router(notification_router, prefix="/api/notifications", tags=["Noti
 app.include_router(analytics_router, prefix="/api/analytics", tags=["Analytics"])
 app.include_router(recommendation_router, prefix="/api/recommendations", tags=["Recommendations"])
 app.include_router(billing_router, prefix="/api/billing", tags=["Billing"])
+app.include_router(quiz_router, prefix="/api/quizzes", tags=["Quizzes"])
 
 # Initialize components
 history_teacher = HistoryTeacher(model="gpt-3.5-turbo")


### PR DESCRIPTION
## Summary
- implement quizzes service with generate, submit and results endpoints
- wire new router into FastAPI app

## Testing
- `pre-commit run --files backend/main.py backend/api/quizzes/__init__.py backend/api/quizzes/crud.py backend/api/quizzes/routes.py backend/api/quizzes/schemas.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d464d0df48333875980b8c3da9920