### PR TITLE
Implement RBAC with role claim

### DIFF
--- a/backend/api/analytics/routes.py
+++ b/backend/api/analytics/routes.py
@@ -11,17 +11,13 @@ router = APIRouter()
 async def get_course_analytics(
     course_id: int,
     db: Session = Depends(get_db),
-    current_user: schemas.User = Depends(auth_crud.get_current_user)
+    current_user: schemas.User = Depends(auth_crud.get_current_teacher)
 ):
-    if not current_user.is_instructor:
-        raise HTTPException(status_code=403, detail="Not authorized to view analytics")
     return crud.get_course_analytics(db, course_id)
 
 @router.get("/instructor/analytics", response_model=schemas.InstructorAnalytics)
 async def get_instructor_analytics(
     db: Session = Depends(get_db),
-    current_user: schemas.User = Depends(auth_crud.get_current_user)
+    current_user: schemas.User = Depends(auth_crud.get_current_teacher)
 ):
-    if not current_user.is_instructor:
-        raise HTTPException(status_code=403, detail="Not authorized to view analytics")
     return crud.get_instructor_analytics(db, current_user.id)

--- a/backend/api/users/crud.py
+++ b/backend/api/users/crud.py
@@ -55,7 +55,11 @@ async def get_users(db: AsyncSession, skip: int = 0, limit: int = 100) -> List[m
 
 async def create_user(db: AsyncSession, user: schemas.UserCreate):
     hashed_password = get_password_hash(user.password)
-    db_user = models.User(email=user.email, hashed_password=hashed_password)
+    db_user = models.User(
+        email=user.email,
+        hashed_password=hashed_password,
+        role="Student",
+    )
     db.add(db_user)
     await db.commit()
     await db.refresh(db_user)

--- a/backend/api/users/models.py
+++ b/backend/api/users/models.py
@@ -13,7 +13,7 @@ class User(Base):
     interests = Column(String)
     completed_lessons = Column(ARRAY(Integer), default=[])
     is_active = Column(Boolean, default=True)
-    is_instructor = Column(Boolean, default=False)
+    role = Column(String, default="Student")
     level = Column(Integer, default=1)
     xp = Column(Integer, default=0)
     achievements = Column(JSON, default=[])

--- a/backend/api/users/schemas.py
+++ b/backend/api/users/schemas.py
@@ -14,6 +14,7 @@ class UserCreate(UserBase):
 class User(UserBase):
     id: int
     is_active: bool
+    role: str
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- switch user model to a `role` field instead of `is_instructor`
- default new users to the **Student** role
- include the role claim in generated access tokens
- add helper to ensure teacher role and use it in analytics API

## Testing
- `pre-commit run --files backend/api/users/models.py backend/api/users/crud.py backend/api/users/schemas.py backend/api/auth/crud.py backend/api/analytics/routes.py`
- `python -m py_compile backend/api/users/models.py backend/api/users/crud.py backend/api/users/schemas.py backend/api/auth/crud.py backend/api/analytics/routes.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687d46480fa08333bf572aa35d558192