### PR TITLE
Add missing __init__ for gradebook

### DIFF
--- a/backend/api/gradebook/__init__.py
+++ b/backend/api/gradebook/__init__.py
@@ -1,0 +1,1 @@
+# Package for gradebook functionality


### PR DESCRIPTION
## Summary
- ensure the gradebook module is recognized as a package by adding `__init__.py`

## Testing
- `pre-commit run --files backend/api/gradebook/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4649ec608333907dc3d16398a13d